### PR TITLE
update_ide_run_command

### DIFF
--- a/ide.sh
+++ b/ide.sh
@@ -235,7 +235,7 @@ sub_docker() {
 
 do_run_backend() {
   cd $BACKEND
-  mvn clean spring-boot:run ${1}
+  mvn clean && mvn spring-boot:run ${1}
   cd $BASEDIR
 }
 


### PR DESCRIPTION
use two mvn command instead of one command, which may free some memery of jvm.

closes #68.